### PR TITLE
Upgrade project.yaml

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -1,8 +1,5 @@
 
-version: '3.0'
-
-expectations:
-  population_size: 1000
+version: '5.0'
 
 actions:
              
@@ -2181,7 +2178,7 @@ actions:
         measure_csv: output/measures/measures_dataset_pmr_2024.csv
 
   run_baseline_data_reference_all:
-    run: stata-mp:latest analysis/000_baseline_data_reference_all.do
+    run: stata-mp:v1 analysis/000_baseline_data_reference_all.do
     needs: [generate_dataset_demographics_disease]
     outputs:
       moderately_sensitive:
@@ -2189,7 +2186,7 @@ actions:
         table1: output/tables/reference_table_rounded_all.csv       
 
   run_baseline_data_diseases:
-    run: stata-mp:latest analysis/001_baseline_data_diseases.do
+    run: stata-mp:v1 analysis/001_baseline_data_diseases.do
     needs: [generate_dataset_demographics_disease]
     outputs:
       moderately_sensitive:
@@ -2197,7 +2194,7 @@ actions:
         table1: output/tables/baseline_table_rounded.csv
 
   run_data_processing:
-    run: stata-mp:latest analysis/002_processing_data.do
+    run: stata-mp:v1 analysis/002_processing_data.do
     needs: [generate_dataset, measures_dataset_asthma_2016, measures_dataset_copd_2016, measures_dataset_chd_2016, measures_dataset_stroke_2016, measures_dataset_heart_failure_2016, measures_dataset_dementia_2016, measures_dataset_multiple_sclerosis_2016, measures_dataset_epilepsy_2016, measures_dataset_crohns_disease_2016, measures_dataset_ulcerative_colitis_2016, measures_dataset_dm_type2_2016, measures_dataset_ckd_2016, measures_dataset_psoriasis_2016, measures_dataset_atopic_dermatitis_2016, measures_dataset_osteoporosis_2016, measures_dataset_rheumatoid_2016, measures_dataset_depression_2016, measures_dataset_depression_broad_2016, measures_dataset_coeliac_2016, measures_dataset_pmr_2016, measures_dataset_asthma_2017, measures_dataset_copd_2017, measures_dataset_chd_2017, measures_dataset_stroke_2017, measures_dataset_heart_failure_2017, measures_dataset_dementia_2017, measures_dataset_multiple_sclerosis_2017, measures_dataset_epilepsy_2017, measures_dataset_crohns_disease_2017, measures_dataset_ulcerative_colitis_2017, measures_dataset_dm_type2_2017, measures_dataset_ckd_2017, measures_dataset_psoriasis_2017, measures_dataset_atopic_dermatitis_2017, measures_dataset_osteoporosis_2017, measures_dataset_rheumatoid_2017, measures_dataset_depression_2017, measures_dataset_depression_broad_2017, measures_dataset_coeliac_2017, measures_dataset_pmr_2017, measures_dataset_asthma_2018, measures_dataset_copd_2018, measures_dataset_chd_2018, measures_dataset_stroke_2018, measures_dataset_heart_failure_2018, measures_dataset_dementia_2018, measures_dataset_multiple_sclerosis_2018, measures_dataset_epilepsy_2018, measures_dataset_crohns_disease_2018, measures_dataset_ulcerative_colitis_2018, measures_dataset_dm_type2_2018, measures_dataset_ckd_2018, measures_dataset_psoriasis_2018, measures_dataset_atopic_dermatitis_2018, measures_dataset_osteoporosis_2018, measures_dataset_rheumatoid_2018, measures_dataset_depression_2018, measures_dataset_depression_broad_2018, measures_dataset_coeliac_2018, measures_dataset_pmr_2018, measures_dataset_asthma_2019, measures_dataset_copd_2019, measures_dataset_chd_2019, measures_dataset_stroke_2019, measures_dataset_heart_failure_2019, measures_dataset_dementia_2019, measures_dataset_multiple_sclerosis_2019, measures_dataset_epilepsy_2019, measures_dataset_crohns_disease_2019, measures_dataset_ulcerative_colitis_2019, measures_dataset_dm_type2_2019, measures_dataset_ckd_2019, measures_dataset_psoriasis_2019, measures_dataset_atopic_dermatitis_2019, measures_dataset_osteoporosis_2019, measures_dataset_rheumatoid_2019, measures_dataset_depression_2019, measures_dataset_depression_broad_2019, measures_dataset_coeliac_2019, measures_dataset_pmr_2019, measures_dataset_asthma_2020, measures_dataset_copd_2020, measures_dataset_chd_2020, measures_dataset_stroke_2020, measures_dataset_heart_failure_2020, measures_dataset_dementia_2020, measures_dataset_multiple_sclerosis_2020, measures_dataset_epilepsy_2020, measures_dataset_crohns_disease_2020, measures_dataset_ulcerative_colitis_2020, measures_dataset_dm_type2_2020, measures_dataset_ckd_2020, measures_dataset_psoriasis_2020, measures_dataset_atopic_dermatitis_2020, measures_dataset_osteoporosis_2020, measures_dataset_rheumatoid_2020, measures_dataset_depression_2020, measures_dataset_depression_broad_2020, measures_dataset_coeliac_2020, measures_dataset_pmr_2020, measures_dataset_asthma_2021, measures_dataset_copd_2021, measures_dataset_chd_2021, measures_dataset_stroke_2021, measures_dataset_heart_failure_2021, measures_dataset_dementia_2021, measures_dataset_multiple_sclerosis_2021, measures_dataset_epilepsy_2021, measures_dataset_crohns_disease_2021, measures_dataset_ulcerative_colitis_2021, measures_dataset_dm_type2_2021, measures_dataset_ckd_2021, measures_dataset_psoriasis_2021, measures_dataset_atopic_dermatitis_2021, measures_dataset_osteoporosis_2021, measures_dataset_rheumatoid_2021, measures_dataset_depression_2021, measures_dataset_depression_broad_2021, measures_dataset_coeliac_2021, measures_dataset_pmr_2021, measures_dataset_asthma_2022, measures_dataset_copd_2022, measures_dataset_chd_2022, measures_dataset_stroke_2022, measures_dataset_heart_failure_2022, measures_dataset_dementia_2022, measures_dataset_multiple_sclerosis_2022, measures_dataset_epilepsy_2022, measures_dataset_crohns_disease_2022, measures_dataset_ulcerative_colitis_2022, measures_dataset_dm_type2_2022, measures_dataset_ckd_2022, measures_dataset_psoriasis_2022, measures_dataset_atopic_dermatitis_2022, measures_dataset_osteoporosis_2022, measures_dataset_rheumatoid_2022, measures_dataset_depression_2022, measures_dataset_depression_broad_2022, measures_dataset_coeliac_2022, measures_dataset_pmr_2022, measures_dataset_asthma_2023, measures_dataset_copd_2023, measures_dataset_chd_2023, measures_dataset_stroke_2023, measures_dataset_heart_failure_2023, measures_dataset_dementia_2023, measures_dataset_multiple_sclerosis_2023, measures_dataset_epilepsy_2023, measures_dataset_crohns_disease_2023, measures_dataset_ulcerative_colitis_2023, measures_dataset_dm_type2_2023, measures_dataset_ckd_2023, measures_dataset_psoriasis_2023, measures_dataset_atopic_dermatitis_2023, measures_dataset_osteoporosis_2023, measures_dataset_rheumatoid_2023, measures_dataset_depression_2023, measures_dataset_depression_broad_2023, measures_dataset_coeliac_2023, measures_dataset_pmr_2023, measures_dataset_asthma_2024, measures_dataset_copd_2024, measures_dataset_chd_2024, measures_dataset_stroke_2024, measures_dataset_heart_failure_2024, measures_dataset_dementia_2024, measures_dataset_multiple_sclerosis_2024, measures_dataset_epilepsy_2024, measures_dataset_crohns_disease_2024, measures_dataset_ulcerative_colitis_2024, measures_dataset_dm_type2_2024, measures_dataset_ckd_2024, measures_dataset_psoriasis_2024, measures_dataset_atopic_dermatitis_2024, measures_dataset_osteoporosis_2024, measures_dataset_rheumatoid_2024, measures_dataset_depression_2024, measures_dataset_depression_broad_2024, measures_dataset_coeliac_2024, measures_dataset_pmr_2024]
     outputs:
       moderately_sensitive:
@@ -2205,7 +2202,7 @@ actions:
         table1: output/tables/redacted_counts_*.csv
 
   run_incidence_graphs:
-    run: stata-mp:latest analysis/100_incidence_graphs.do
+    run: stata-mp:v1 analysis/100_incidence_graphs.do
     needs: [run_data_processing]
     outputs:
       moderately_sensitive:
@@ -2221,7 +2218,7 @@ actions:
         table1: output/tables/arima_standardised.csv
 
   run_sarima:
-    run: r:latest analysis/200_sarima.R
+    run: r:v1 analysis/200_sarima.R
     needs: [run_incidence_graphs]
     outputs:
       moderately_sensitive:


### PR DESCRIPTION
This upgrades the project.yaml to v5.0 (version 3.0 will be deprecated soon).

It updates `stata-mp:latest` to `stata-mp:v1` and `r:latest` to `r:v1` ; this makes no difference to the action that is run (latest is just an alias for v1). The use of latest as a version tag has been deprecated. You may want to update to `r:v2` to use the current r image, however.

It also removes the obsolete expectations section from the project.yaml (it was only relevant for old pre-ehrql actions, and no longer does anything).